### PR TITLE
Feat: 공구 정보 수정 API

### DIFF
--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
@@ -56,4 +56,17 @@ public class GroupPurchaseController {
         GroupPurchaseResponse.GroupPurchaseDetailDTO response = groupPurchaseService.getGroupPurchaseDetail(groupPurchaseId);
         return ApiResponse.onSuccess(SuccessStatus.GROUP_PURCHASE_FETCH_DETAIL_OK, response);
     }
+
+    // 공구 정보 수정 API
+    @Operation(summary = "공동구매 정보 수정", description = "공동구매 정보를 수정하는 API 입니다.")
+    @Parameter(name = "groupPurchaseId", description = "정보를 수정할 공동구매의 ID입니다.")
+    @PatchMapping("/{groupPurchaseId}")
+    public ApiResponse<GroupPurchaseResponse.GroupPurchaseIdDTO> updateGroupPurchase(
+        @PathVariable("groupPurchaseId") Long groupPurchaseId,
+        @RequestBody GroupPurchaseRequest.GroupPurchaseUpdateDTO request
+    ){
+        GroupPurchase groupPurchase = groupPurchaseService.updateGroupPurchase(groupPurchaseId, request);
+        GroupPurchaseResponse.GroupPurchaseIdDTO response = GroupPurchaseConverter.toGroupPurchaseIdDTO(groupPurchase);
+        return ApiResponse.onSuccess(SuccessStatus.GROUP_PURCHASE_UPDATE_OK, response);
+    }
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/dto/GroupPurchaseRequest.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/dto/GroupPurchaseRequest.java
@@ -1,21 +1,40 @@
 package com.capstone2.capstone2.domain.groupPurchase.dto;
 
+import com.capstone2.capstone2.domain.model.enums.Status;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class GroupPurchaseRequest {
 
     @Data
     @Builder
     public static class GroupPurchaseCreateDTO {
-        String title;
-        String name;
-        String image;
-        String category1;
-        String category2;
-        String content;
-        int price;
-        int quantity;
-        int participants;
+        private String title;
+        private String content;
+        private String name;
+        private String image;
+        private String category1;
+        private String category2;
+        private int price;
+        private int quantity;
+        private int participants;
+    }
+
+    @Data
+    @Builder
+    public static class GroupPurchaseUpdateDTO {
+        private String title;
+        private String content;
+        private String place;
+        private String name;
+        private int quantity;
+        private List<String> imageUrls;
+        private int participants;
+        private String category1;
+        private String category2;
+        private LocalDateTime deadline;
     }
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/dto/GroupPurchaseRequest.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/dto/GroupPurchaseRequest.java
@@ -1,6 +1,5 @@
 package com.capstone2.capstone2.domain.groupPurchase.dto;
 
-import com.capstone2.capstone2.domain.model.enums.Status;
 import lombok.Builder;
 import lombok.Data;
 
@@ -15,7 +14,7 @@ public class GroupPurchaseRequest {
         private String title;
         private String content;
         private String name;
-        private String image;
+        private String imageUrl;
         private String category1;
         private String category2;
         private int price;

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchase.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchase.java
@@ -1,5 +1,6 @@
 package com.capstone2.capstone2.domain.groupPurchase.entity;
 
+import com.capstone2.capstone2.domain.groupPurchase.dto.GroupPurchaseRequest;
 import com.capstone2.capstone2.domain.member.entity.Member;
 import com.capstone2.capstone2.domain.model.enums.Status;
 import com.capstone2.capstone2.domain.model.entity.BaseEntity;
@@ -70,4 +71,25 @@ public class GroupPurchase extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "groupPurchase", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupPurchaseImage> groupPurchaseImages = new ArrayList<>();
+
+    // 공동 구매 정보 수정
+    public void updateGroupPurchase(GroupPurchaseRequest.GroupPurchaseUpdateDTO request) {
+        this.title = request.getTitle();
+        this.content = request.getContent();
+        this.place = request.getPlace();
+        this.name = request.getName();
+        this.quantity = request.getQuantity();
+        this.participants = request.getParticipants();
+        this.category1 = request.getCategory1();
+        this.category2 = request.getCategory2();
+        this.deadline = request.getDeadline();
+
+        this.groupPurchaseImages.clear();
+        if (request.getImageUrls() != null) {
+            for (String imageUrl: request.getImageUrls()) {
+                GroupPurchaseImage image = new GroupPurchaseImage(this, imageUrl);
+                this.groupPurchaseImages.add(image);
+            }
+        }
+    }
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchase.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchase.java
@@ -92,4 +92,8 @@ public class GroupPurchase extends BaseEntity {
             }
         }
     }
+
+    public void increaseViews() {
+        this.views += 1;
+    }
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchaseImage.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchaseImage.java
@@ -10,6 +10,11 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class GroupPurchaseImage extends BaseEntity {
+
+    public GroupPurchaseImage(GroupPurchase groupPurchase, String imageUrl) {
+        this.groupPurchase = groupPurchase;
+        this.imageUrl = imageUrl;
+    }
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
@@ -9,4 +9,5 @@ public interface GroupPurchaseService {
     GroupPurchase createGroupPurchase(Long memberId, GroupPurchaseRequest.GroupPurchaseCreateDTO request);
     Page<GroupPurchaseResponse.GroupPurchaseListDTO> getAllPurchases(int page, int size);
     GroupPurchaseResponse.GroupPurchaseDetailDTO getGroupPurchaseDetail(Long purchaseId);
+    GroupPurchase updateGroupPurchase(Long groupPurchaseId, GroupPurchaseRequest.GroupPurchaseUpdateDTO request);
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -73,5 +72,16 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
 
         GroupPurchaseResponse.GroupPurchaseDetailDTO response = GroupPurchaseConverter.toGroupPurchaseDetailDTO(groupPurchase, writerName, imageUrls);
         return response;
+    }
+
+    // 공구 정보 수정
+    @Override
+    @Transactional
+    public GroupPurchase updateGroupPurchase(Long groupPurchaseId, GroupPurchaseRequest.GroupPurchaseUpdateDTO request) {
+        GroupPurchase groupPurchase = groupPurchaseRepository.findById(groupPurchaseId)
+                .orElseThrow(() -> new GroupPurchaseHandler(ErrorStatus.GROUP_PURCHASE_ID_NULL));
+
+        groupPurchase.updateGroupPurchase(request);
+        return groupPurchase;
     }
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
@@ -61,9 +61,12 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
 
     // 공구 상세 조회
     @Override
+    @Transactional
     public GroupPurchaseResponse.GroupPurchaseDetailDTO getGroupPurchaseDetail(Long purchaseId) {
         GroupPurchase groupPurchase = groupPurchaseRepository.findById(purchaseId)
                 .orElseThrow(() -> new GroupPurchaseHandler(ErrorStatus.GROUP_PURCHASE_ID_NULL));
+
+        groupPurchase.increaseViews(); // 조회 시 조회수 1 증가
 
         String writerName = groupPurchase.getWriter().getNickname();
         List<String> imageUrls = groupPurchase.getGroupPurchaseImages().stream()

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
@@ -44,7 +44,7 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
                 GroupPurchaseConverter.toGroupPurchase(member, request)
         );
 
-        GroupPurchaseImage image = GroupPurchaseConverter.toGroupPurchaseImage(groupPurchase, request.getImage());
+        GroupPurchaseImage image = GroupPurchaseConverter.toGroupPurchaseImage(groupPurchase, request.getImageUrl());
         groupPurchaseImageRepository.save(image);
 
         return groupPurchase;

--- a/src/main/java/com/capstone2/capstone2/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/capstone2/capstone2/global/error/code/status/SuccessStatus.java
@@ -21,6 +21,8 @@ public enum SuccessStatus implements BaseCode {
     GROUP_PURCHASE_CREATE_OK(HttpStatus.OK, "GROUP_PURCHASE2001", "공동 구매 생성이 완료되었습니다."),
     GROUP_PURCHASE_FETCH_ALL_OK(HttpStatus.OK, "GROUP_PURCHASE2002", "공동 구매 전체 조회가 완료되었습니다."),
     GROUP_PURCHASE_FETCH_DETAIL_OK(HttpStatus.OK, "GROUP_PURCHASE2003", "공동 구매 상세 조회가 완료되었습니다."),
+    GROUP_PURCHASE_UPDATE_OK(HttpStatus.OK, "GROUP_PURCHASE2004", "공동 구매 정보 수정이 완료되었습니다."),
+
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #18 

## 📝작업 내용
> 공구 정보 수정 API 구현

GroupPurchase에서 이미지 수정 시 GroupPurchaseImage도 수정되는 거 확인했습니다

입력
<img width="221" alt="image" src="https://github.com/user-attachments/assets/8a680c9b-adca-4e65-8c2c-6fff8fae67a6" />


결과
<img width="289" alt="image" src="https://github.com/user-attachments/assets/1c04d34f-40dd-480c-8e40-9fa1c041fd5f" />


## 🔎코드 설명 및 참고 사항
>

추가로 공구 조회 시 공구 views 1씩 증가하게끔 하는 기능도 추가했습니다
## 💬리뷰 요구사항
>
