### PR TITLE
Feat: 특정 카테고리의 공구 목록 조회 API

### DIFF
--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
@@ -89,7 +89,23 @@ public class GroupPurchaseController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-       Page<GroupPurchaseResponse.GroupPurchaseListDTO> response = groupPurchaseService.getPopularGroupPurchases(sort, page, size);
+       Page<GroupPurchaseResponse.GroupPurchaseListDTO> response =
+               groupPurchaseService.getPopularGroupPurchases(sort, page, size);
        return ApiResponse.onSuccess(SuccessStatus.GROUP_PURCHASE_FETCH_RANKING_OK, response);
     }
+
+    // 특정 카테고리의 공구 목록 조회
+    @GetMapping("/category")
+    @Operation(summary = "카테고리별 공구 목록 조회", description = "대분류(category1), 소분류(cateogry2)를 기준으로 공구 목록을 조회하는 API입니다. 페이지는 1부터 시작합니다.")
+    public ApiResponse<Page<GroupPurchaseResponse.GroupPurchaseListDTO>> getGroupPurchaseByCategory(
+            @RequestParam String category1,
+            @RequestParam(required = false) String category2,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Page<GroupPurchaseResponse.GroupPurchaseListDTO> response =
+                groupPurchaseService.getGroupPurchasesByCategory(category1, category2, page, size);
+        return ApiResponse.onSuccess(SuccessStatus.GROUP_PURCHASE_FETCH_BY_CATEGORY, response);
+    }
+
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/repository/GroupPurchaseRepository.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/repository/GroupPurchaseRepository.java
@@ -1,7 +1,11 @@
 package com.capstone2.capstone2.domain.groupPurchase.repository;
 
 import com.capstone2.capstone2.domain.groupPurchase.entity.GroupPurchase;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupPurchaseRepository extends JpaRepository<GroupPurchase, Long> {
+    Page<GroupPurchase> findByCategory1(String category1, Pageable pageable);
+    Page<GroupPurchase> findByCategory1AndCategory2(String category1, String category2, Pageable pageable);
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
@@ -12,4 +12,5 @@ public interface GroupPurchaseService {
     GroupPurchase updateGroupPurchase(Long groupPurchaseId, GroupPurchaseRequest.GroupPurchaseUpdateDTO request);
     void deleteGroupPurchase(Long groupPurchaseId);
     Page<GroupPurchaseResponse.GroupPurchaseListDTO> getPopularGroupPurchases(String sort, int page ,int size);
+    Page<GroupPurchaseResponse.GroupPurchaseListDTO> getGroupPurchasesByCategory(String category1, String category2, int page, int size);
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
@@ -113,4 +113,21 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
 
         return groupPurchases.map(GroupPurchaseConverter::toGroupPurchaseListDTO);
     }
+
+
+    // 카테고리 별 공구 목록 조회
+    @Override
+    public Page<GroupPurchaseResponse.GroupPurchaseListDTO> getGroupPurchasesByCategory(String category1, String category2, int page, int size) {
+        Pageable pageable = PageRequest.of(page -1 , size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<GroupPurchase> groupPurchases;
+
+        if (category2 != null && !category2.isBlank()) {
+            groupPurchases = groupPurchaseRepository.findByCategory1AndCategory2(category1, category2, pageable);
+        } else {
+            groupPurchases = groupPurchaseRepository.findByCategory1(category1, pageable);
+        }
+
+        return groupPurchases.map(GroupPurchaseConverter::toGroupPurchaseListDTO);
+    }
 }

--- a/src/main/java/com/capstone2/capstone2/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/capstone2/capstone2/global/error/code/status/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus implements BaseCode {
     GROUP_PURCHASE_UPDATE_OK(HttpStatus.OK, "GROUP_PURCHASE2004", "공동 구매 정보 수정이 완료되었습니다."),
     GROUP_PURCHASE_DELETE_OK(HttpStatus.OK, "GROUP_PURCHASE2005", "공동 구매 삭제가 완료되었습니다."),
     GROUP_PURCHASE_FETCH_RANKING_OK(HttpStatus.OK, "GROUP_PURCHASE2006", "인기 공동 구매 조회가 완료되었습니다."),
+    GROUP_PURCHASE_FETCH_BY_CATEGORY(HttpStatus.OK, "GROUP_PURCHASE2007", "카테고리 별 공동 구매 목록 조회가 완료되었습니다."),
 
     ;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #24 

## 📝작업 내용
> 카테고리별 공구 목록 조회

category1(대분류), category2(소분류)를 파라미터로 받아 해당 카테고리의 공구 목록을 반환합니다.

category1은 필수 입력값이고, category2는 선택입니다.
category2를 입력하지 않을 시 cateogory1에 해당하는 공구 목록을 반환합니다.

페이징 적용됐습니다.

category1, category2를 모두 입력 시 두 카테고리가 모두 일치하는 공구 목록 반환

category1만 입력시 category1이 같은 공구 목록 반환 (category2는 상관 X)

API 명세는 스웨거 참고

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
