### PR TITLE
kakao api 수정

### DIFF
--- a/src/main/java/com/capstone2/capstone2/global/oauth/JwtTokenProvider.java
+++ b/src/main/java/com/capstone2/capstone2/global/oauth/JwtTokenProvider.java
@@ -1,0 +1,30 @@
+package com.capstone2.capstone2.global.oauth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.expiration-ms}")
+    private long validityInMs;
+
+    /** userId를 subject로 담아 JWT 생성 */
+    public String generateToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validityInMs);
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/capstone2/capstone2/global/oauth/controller/AuthController.java
+++ b/src/main/java/com/capstone2/capstone2/global/oauth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.capstone2.capstone2.domain.member.dto.MemberResponseDTO;
 import com.capstone2.capstone2.domain.member.entity.Member;
 import com.capstone2.capstone2.global.common.response.ApiResponse;
 import com.capstone2.capstone2.global.error.code.status.SuccessStatus;
+import com.capstone2.capstone2.global.oauth.dto.LoginResponseDTO;
 import com.capstone2.capstone2.global.oauth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,12 +27,28 @@ public class AuthController {
     @Value("${app.front.redirect-url}")
     private String frontRedirectUrl;
 
+
     @GetMapping("/login/kakao")
-    @Operation(summary = "kakao login API", description = "인가 코드를 받아 로그인 처리 후 토큰과 사용자 정보를 JSON으로 반환합니다.")
-    public ApiResponse<MemberResponseDTO.JoinResultDTO> kakaoLogin(
+    @Operation(summary = "kakao login (JSON)", description = "인가 코드 처리 후 JSON으로 토큰·유저 정보를 반환하고, 클라이언트에서 라우터 이동을 제어합니다.")
+    public ApiResponse<LoginResponseDTO> kakaoLoginJson(
             @RequestParam("code") String accessCode, HttpServletResponse httpServletResponse) {
-        System.out.println("🔥 kakaoLogin 실행됨");  // 이게 안 보이면 요청이 안 들어온 것
         Member member = authService.oAuthLogin(accessCode, httpServletResponse);
-        return ApiResponse.onSuccess(SuccessStatus.USER_EMAIL_LOGIN_OK, MemberConverter.toJoinResultDTO(member));
+        String jwt = authService.createToken(member);
+        MemberResponseDTO.JoinResultDTO userDto = MemberConverter.toJoinResultDTO(member);
+        LoginResponseDTO responseDto = new LoginResponseDTO(jwt, userDto);
+        return ApiResponse.onSuccess(SuccessStatus.USER_EMAIL_LOGIN_OK, responseDto);
+    }
+
+
+    @GetMapping("/login/kakao/redirect")
+    @Operation(summary = "kakao login (Redirect)", description = "인가 코드 처리 후 302 리다이렉트 방식으로 클라이언트 라우트로 이동시킵니다.")
+    public void kakaoLoginRedirect(
+            @RequestParam("code") String accessCode,
+            HttpServletResponse response) throws IOException {
+        Member member = authService.oAuthLogin(accessCode, response);
+        String jwt = authService.createToken(member);
+        // 쿼리 파라미터에 token, userId 전달
+        String redirectUri = String.format("%s?token=%s&userId=%d", frontRedirectUrl, jwt, member.getId());
+        response.sendRedirect(redirectUri);
     }
 }

--- a/src/main/java/com/capstone2/capstone2/global/oauth/dto/LoginResponseDTO.java
+++ b/src/main/java/com/capstone2/capstone2/global/oauth/dto/LoginResponseDTO.java
@@ -1,0 +1,12 @@
+package com.capstone2.capstone2.global.oauth.dto;
+
+import com.capstone2.capstone2.domain.member.dto.MemberResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LoginResponseDTO {
+    private String token;
+    private MemberResponseDTO.JoinResultDTO user;
+}

--- a/src/main/java/com/capstone2/capstone2/global/oauth/service/AuthService.java
+++ b/src/main/java/com/capstone2/capstone2/global/oauth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.capstone2.capstone2.domain.member.dto.MemberResponseDTO;
 import com.capstone2.capstone2.domain.member.entity.Member;
 import com.capstone2.capstone2.domain.member.repository.MemberRepository;
 import com.capstone2.capstone2.global.error.code.status.ErrorStatus;
+import com.capstone2.capstone2.global.oauth.JwtTokenProvider;
 import com.capstone2.capstone2.global.oauth.converter.AuthConverter;
 import com.capstone2.capstone2.global.oauth.dto.KakaoDTO;
 import com.capstone2.capstone2.global.oauth.dto.KakaoTokenResponseDTO;
@@ -105,5 +106,9 @@ public class AuthService {
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .build();
+    }
+    private final JwtTokenProvider jwtTokenProvider;  // 이 줄 추가
+    public String createToken(Member member) {
+        return jwtTokenProvider.generateToken(member.getId());
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,9 +36,10 @@ kakao:
 #  redirect: http://localhost:8080/auth/login/kakao-test
 app:
   front:
-    redirect-url: http://localhost:3000/oauth2/redirect
+    redirect-url: http://localhost:5173/landing
 jwt:
   secret: ${JWT_SECRET}
+  expiration-ms: 3600000
 
 naver:
   search:


### PR DESCRIPTION
## #️⃣연관된 이슈
> #46 

## 📝작업 내용
> 카카오 로그인 후 프론트에게 토큰 번호 주기 , 페이지 넘겨주기 방식 2개로 구현

## 🔎코드 설명 및 참고 사항
> 
1번 방식 : 302 리다이렉트 방식
-> 로그인 후 브라우저가 자동으로 해당 URL로 이동

2번 방식 : 프론트에서 JSON 받고 클라이언트 라우터로 이동
현재처럼 JSON을 내려준 뒤
프론트(React/Vue)에서 fetch('/auth/login/kakao?code=…') 호출 후
예시
fetch('/auth/login/kakao?code=' + code)
  .then(res => res.json())
  .then(data => {
    // 토큰·유저 정보를 저장하고
    localStorage.setItem('ACCESS_TOKEN', data.data.token);
    // 라우터로 이동
    window.location.href = 'http://localhost:5173/landing';
  });
프론트 쪽 자바스크립트에서 직접 페이지 이동을 제어

## 💬리뷰 요구사항
>
