### PR TITLE
Feat: 검색 API 구현

### DIFF
--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
@@ -140,4 +140,29 @@ public class GroupPurchaseController {
         GroupPurchaseResponse.GroupPurchaseIdDTO response = GroupPurchaseConverter.toGroupPurchaseIdDTO(groupPurchase);
         return ApiResponse.onSuccess(SuccessStatus.GROUP_PURCHASE_PARTICIPATE_CANCEL_OK, response);
     }
+
+    @Operation(
+            summary = "공구 검색 (품목명, 지역, 카테고리, 정렬, 페이징)",
+            description = "itemName: 검색어, category: 대분류 카테고리 (선택), sort: views|latest|oldest|likes (default=latest), "
+                    + "page:페이지번호(default=1), size:페이지크기(default=10), memberId:조회자의 ID"
+    )
+    @GetMapping("/search/items")
+    public ApiResponse<Page<GroupPurchaseResponse.GroupPurchaseListDTO>> searchItems(
+            @RequestParam("memberId") Long memberId,
+            @RequestParam("itemName") String itemName,
+            @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "sort",    defaultValue = "latest") String sort,
+            @RequestParam(value = "page",    defaultValue = "1")      int page,
+            @RequestParam(value = "size",    defaultValue = "10")     int size
+    ) {
+        Page<GroupPurchaseResponse.GroupPurchaseListDTO> pageResult
+                = groupPurchaseService.searchGroupPurchases(
+                memberId, itemName, category, sort, page, size);
+
+        return ApiResponse.onSuccess(
+                SuccessStatus.GROUP_PURCHASE_SEARCH_OK, // enum에 추가 필요
+                pageResult
+        );
+    }
+
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/repository/GroupPurchaseRepository.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/repository/GroupPurchaseRepository.java
@@ -8,4 +8,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GroupPurchaseRepository extends JpaRepository<GroupPurchase, Long> {
     Page<GroupPurchase> findByCategory1(String category1, Pageable pageable);
     Page<GroupPurchase> findByCategory1AndCategory2(String category1, String category2, Pageable pageable);
+
+    // 아이템명 + 동네 필터
+    Page<GroupPurchase> findByNameContainingAndWriter_CurrentTown_Id(
+            String name, Long townId, Pageable pageable);
+
+    // 아이템명 + 카테고리1 + 동네 필터
+    Page<GroupPurchase> findByNameContainingAndCategory1AndWriter_CurrentTown_Id(
+            String name, String category1, Long townId, Pageable pageable);
+
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
@@ -15,4 +15,14 @@ public interface GroupPurchaseService {
     Page<GroupPurchaseResponse.GroupPurchaseListDTO> getGroupPurchasesByCategory(String category1, String category2, int page, int size);
     GroupPurchase participateGroupPurchase(Long groupPurchaseId, Long memberId);
     GroupPurchase cancelGroupPurchaseParticipate(Long groupPurchaseId, Long memberId);
+
+
+    Page<GroupPurchaseResponse.GroupPurchaseListDTO> searchGroupPurchases(
+            Long memberId,
+            String itemName,
+            String category,    // nullable
+            String sort,        // views, oldest, likes, latest
+            int page,
+            int size
+    );
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
@@ -228,4 +228,56 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
 
         return groupPurchase;
     }
+
+    @Override
+    public Page<GroupPurchaseResponse.GroupPurchaseListDTO> searchGroupPurchases(
+            Long memberId,
+            String itemName,
+            String category,
+            String sort,
+            int page,
+            int size
+    ) {
+        // 1) 멤버 조회해서 currentTown.id 가져오기
+        Long townId = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL))
+                .getCurrentTown()
+                .getId();
+
+        // 2) 정렬 기준
+        Sort sorting;
+        switch (sort.toLowerCase()) {
+            case "views":
+                sorting = Sort.by(Sort.Order.desc("views"));
+                break;
+            case "oldest":
+                sorting = Sort.by(Sort.Direction.ASC, "createdAt");
+                break;
+            case "likes":
+                sorting = Sort.by(Sort.Direction.DESC, "likes");
+                break;
+            case "latest":
+            default:
+                sorting = Sort.by(Sort.Direction.DESC, "createdAt");
+                break;
+        }
+        Pageable pageable = PageRequest.of(page - 1, size, sorting);
+
+        // 3) 검색 실행
+        Page<GroupPurchase> results;
+        if (category != null && !category.isBlank()) {
+            results = groupPurchaseRepository
+                    .findByNameContainingAndCategory1AndWriter_CurrentTown_Id(
+                            itemName, category, townId, pageable);
+        } else {
+            results = groupPurchaseRepository
+                    .findByNameContainingAndWriter_CurrentTown_Id(
+                            itemName, townId, pageable);
+        }
+
+        // 4) DTO 변환
+        return results.map(GroupPurchaseConverter::toGroupPurchaseListDTO);
+    }
+
+
 }

--- a/src/main/java/com/capstone2/capstone2/global/error/code/status/SuccessStatus.java
+++ b/src/main/java/com/capstone2/capstone2/global/error/code/status/SuccessStatus.java
@@ -57,6 +57,9 @@ public enum SuccessStatus implements BaseCode {
 
     // 채팅방
     CHATROOM_LIST_OK(HttpStatus.OK, "CHATROOM_2001", "채팅방 목록 조회가 완료되었습니다."),
+
+    // 검색
+    GROUP_PURCHASE_SEARCH_OK(HttpStatus.OK, "SEARCH_2001", "검색이 완료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #39 

## 📝작업 내용
> 검색 API를 구현했습니다
품목명 기반 공구 검색(지역, 카테고리, 정렬 등 필터 포함)API GET /purchases/search/items
Paging 들어가도록(page는 default로 1부터 시작, size도 default로 10)
	1	공구물품명 기반으로 공구 검색
	2	필터 : 멤버의 지역(town(nullable = false)), 카테고리(string)
	3	정렬 :조회수, 최신순, 오래된 순, 찜순 (default는 최신순)


## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
