### PR TITLE
Refactor: 공구 등록 시 해당 공구의 districtId 저장

### DIFF
--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/controller/GroupPurchaseController.java
@@ -37,13 +37,15 @@ public class GroupPurchaseController {
 
     // 공구 전체 목록 조회 API
     @Operation(summary = "공동구매 전체 목록 조회", description = "공동구매 전체 목록을 조회하는 API입니다. 페이지는 1부터 시작합니다.")
-    @GetMapping
+    @Parameter(name = "memberId", description = "공구를 등록하는 멤버의 ID, 추후 hidden으로 수정 예정입니다.")
+    @GetMapping("/{memberId}")
     public ApiResponse<Page<GroupPurchaseResponse.GroupPurchaseListDTO>> getAllGroupPurchases(
+        @PathVariable("memberId") Long memberId,
         @RequestParam(defaultValue = "1") int page,
         @RequestParam(defaultValue = "10") int size
     ){
 
-        Page<GroupPurchaseResponse.GroupPurchaseListDTO> response = groupPurchaseService.getAllPurchases(page, size);
+        Page<GroupPurchaseResponse.GroupPurchaseListDTO> response = groupPurchaseService.getAllPurchases(memberId, page, size);
         return ApiResponse.onSuccess(SuccessStatus.GROUP_PURCHASE_FETCH_ALL_OK, response);
     }
 

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/converter/GroupPurchaseConverter.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/converter/GroupPurchaseConverter.java
@@ -10,7 +10,7 @@ import com.capstone2.capstone2.domain.model.enums.Status;
 import java.util.List;
 
 public class GroupPurchaseConverter {
-    public static GroupPurchase toCreateGroupPurchase(Member member, GroupPurchaseRequest.GroupPurchaseCreateDTO request) {
+    public static GroupPurchase toCreateGroupPurchase(Member member, GroupPurchaseRequest.GroupPurchaseCreateDTO request, Long districtId) {
         return GroupPurchase.builder()
                 .title(request.getTitle())
                 .name(request.getName())
@@ -18,6 +18,7 @@ public class GroupPurchaseConverter {
                 .category2(request.getCategory2())
                 .content(request.getContent())
                 .quantity(request.getQuantity())
+                .currentDistrictId(districtId)
                 .maxParticipants(request.getMaxParticipants())
                 .currentParticipants(0)
                 .price(request.getPrice())

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchase.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/entity/GroupPurchase.java
@@ -75,6 +75,9 @@ public class GroupPurchase extends BaseEntity {
     // 마감 예측 시간
     private LocalDateTime deadline;
 
+    @Column(name = "current_district_id", nullable = false)
+    private Long currentDistrictId;
+
     @Builder.Default
     @OneToMany(mappedBy = "groupPurchase", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupPurchaseImage> groupPurchaseImages = new ArrayList<>();

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/repository/GroupPurchaseRepository.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/repository/GroupPurchaseRepository.java
@@ -1,6 +1,7 @@
 package com.capstone2.capstone2.domain.groupPurchase.repository;
 
 import com.capstone2.capstone2.domain.groupPurchase.entity.GroupPurchase;
+import com.capstone2.capstone2.domain.model.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,9 @@ public interface GroupPurchaseRepository extends JpaRepository<GroupPurchase, Lo
     Page<GroupPurchase> findByNameContainingAndCategory1AndWriter_CurrentTown_Id(
             String name, String category1, Long townId, Pageable pageable);
 
+    Page<GroupPurchase> findByStatusAndCurrentDistrictId(
+            Status status,
+            Long currentDistrictId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 
 public interface GroupPurchaseService {
     GroupPurchase createGroupPurchase(Long memberId, GroupPurchaseRequest.GroupPurchaseCreateDTO request);
-    Page<GroupPurchaseResponse.GroupPurchaseListDTO> getAllPurchases(int page, int size);
+    Page<GroupPurchaseResponse.GroupPurchaseListDTO> getAllPurchases(Long memberId, int page, int size);
     GroupPurchaseResponse.GroupPurchaseDetailDTO getGroupPurchaseDetail(Long purchaseId);
     GroupPurchase updateGroupPurchase(Long groupPurchaseId, GroupPurchaseRequest.GroupPurchaseUpdateDTO request);
     void deleteGroupPurchase(Long groupPurchaseId);

--- a/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
+++ b/src/main/java/com/capstone2/capstone2/domain/groupPurchase/service/GroupPurchaseServiceImpl.java
@@ -19,6 +19,7 @@ import com.capstone2.capstone2.domain.groupPurchase.repository.ParticipationRepo
 import com.capstone2.capstone2.domain.member.entity.Member;
 import com.capstone2.capstone2.domain.member.handler.MemberHandler;
 import com.capstone2.capstone2.domain.member.repository.MemberRepository;
+import com.capstone2.capstone2.domain.model.enums.Status;
 import com.capstone2.capstone2.global.error.code.status.ErrorStatus;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -51,9 +52,11 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL));
 
+        Long districtId = member.getCurrentTown().getDistrict().getId();
+
         // 1. 공구 생성
         GroupPurchase groupPurchase = groupPurchaseRepository.save(
-                GroupPurchaseConverter.toCreateGroupPurchase(member, request)
+                GroupPurchaseConverter.toCreateGroupPurchase(member, request, districtId)
         );
 
         // 2. 이미지 저장
@@ -79,11 +82,18 @@ public class GroupPurchaseServiceImpl implements GroupPurchaseService{
 
     // 공구 전체 조회
     @Override
-    public Page<GroupPurchaseResponse.GroupPurchaseListDTO> getAllPurchases(int page, int size) {
+    public Page<GroupPurchaseResponse.GroupPurchaseListDTO> getAllPurchases(Long memberId, int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<GroupPurchase> groupPurchases = groupPurchaseRepository.findAll(pageable);
+        // Page<GroupPurchase> groupPurchases = groupPurchaseRepository.findAll(pageable);
 
-        return groupPurchases.map(GroupPurchaseConverter::toGroupPurchaseListDTO);
+        Long districtId = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_ID_NULL))
+                .getCurrentTown()
+                .getDistrict()
+                .getId();
+
+        return groupPurchaseRepository.findByStatusAndCurrentDistrictId(Status.ACTIVE, districtId, pageable)
+                .map(GroupPurchaseConverter::toGroupPurchaseListDTO);
     }
 
     // 공구 상세 조회


### PR DESCRIPTION
## #️⃣연관된 이슈
> #68 

## 📝작업 내용
> 공구 등록 시 해당 공구의 districtId 저장
> 공구 목록 조회 시 사용자의 district에 속해있는 공구만 조회되도록 변경

## 🔎코드 설명 및 참고 사항
>

## 💬리뷰 요구사항
>
